### PR TITLE
Use correct date comparison for age elligibility check

### DIFF
--- a/lung_cancer_screening/questions/tests/unit/views/test_have_you_ever_smoked.py
+++ b/lung_cancer_screening/questions/tests/unit/views/test_have_you_ever_smoked.py
@@ -49,16 +49,16 @@ class TestHaveYouEverSmoked(TestCase):
 
         self.assertRedirects(response, reverse("questions:start"))
 
-    def test_post_stores_a_valid_date_response_for_the_participant(self):
+    def test_post_stores_a_valid_boolean_response_for_the_participant(self):
         self.client.post(
             reverse("questions:have_you_ever_smoked"),
             self.valid_params
         )
 
-        date_response = BooleanResponse.objects.first()
-        self.assertEqual(date_response.value, self.valid_params["value"])
-        self.assertEqual(date_response.participant, self.participant)
-        self.assertEqual(date_response.question, "Have you ever smoked?")
+        boolean_response = BooleanResponse.objects.first()
+        self.assertEqual(boolean_response.value, self.valid_params["value"])
+        self.assertEqual(boolean_response.participant, self.participant)
+        self.assertEqual(boolean_response.question, "Have you ever smoked?")
 
     def test_post_sets_the_participant_id_in_session(self):
         self.client.post(

--- a/lung_cancer_screening/questions/views/date_of_birth.py
+++ b/lung_cancer_screening/questions/views/date_of_birth.py
@@ -26,7 +26,7 @@ def date_of_birth(request):
             fifty_five_years_ago = date.today() - relativedelta(years=55)
             seventy_five_years_ago = date.today() - relativedelta(years=75)
 
-            if value in (fifty_five_years_ago, seventy_five_years_ago):
+            if (seventy_five_years_ago < value <= fifty_five_years_ago):
                 DateResponse.objects.create(
                     participant=participant,
                     value=value,


### PR DESCRIPTION
# What is the change?

Use correct date comparison for age elligibility check

# Why are we making this change?

Checking for `age in range` does not work 