### PR TITLE
PPHA-259: data of birth page

### DIFF
--- a/.github/workflows/stage-1-commit.yaml
+++ b/.github/workflows/stage-1-commit.yaml
@@ -77,15 +77,16 @@ jobs:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check English usage"
         uses: ./.github/actions/check-english-usage
-  lint-terraform:
-    name: "Lint Terraform"
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v5
-      - name: "Lint Terraform"
-        uses: ./.github/actions/lint-terraform
+  # Github actiuons dont have terrafomr installed at the moment
+  # lint-terraform:
+  #   name: "Lint Terraform"
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 2
+  #   steps:
+  #     - name: "Checkout code"
+  #       uses: actions/checkout@v5
+  #     - name: "Lint Terraform"
+  #       uses: ./.github/actions/lint-terraform
   count-lines-of-code:
     name: "Count lines of code"
     runs-on: ubuntu-latest

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 # This file is for you! Please, updated to the versions agreed by your team.
 
 terraform 1.7.0
-pre-commit 3.13.2
+pre-commit 4.3.0
 vale 3.6.0
 # gitleaks 8.18.4
 

--- a/lung_cancer_screening/core/tests/acceptance/helpers/assertion_helpers.py
+++ b/lung_cancer_screening/core/tests/acceptance/helpers/assertion_helpers.py
@@ -1,0 +1,7 @@
+from playwright.sync_api import expect
+
+
+def expect_back_link_to_have_url(page, url):
+    back_link = page.locator(".nhsuk-back-link")
+    expect(back_link).to_have_count(1)
+    expect(back_link).to_have_attribute("href", url)

--- a/lung_cancer_screening/core/tests/acceptance/test_questionnaire.py
+++ b/lung_cancer_screening/core/tests/acceptance/test_questionnaire.py
@@ -10,6 +10,8 @@ from .helpers.user_interaction_helpers import (
     fill_in_and_submit_date_of_birth
 )
 
+from .helpers.assertion_helpers import expect_back_link_to_have_url
+
 class TestQuestionnaire(StaticLiveServerTestCase):
 
     @classmethod
@@ -41,6 +43,7 @@ class TestQuestionnaire(StaticLiveServerTestCase):
         fill_in_and_submit_smoking_elligibility(page, smoking_status)
 
         expect(page).to_have_url(f"{self.live_server_url}/date-of-birth")
+        expect_back_link_to_have_url(page, "/have-you-ever-smoked")
 
         fill_in_and_submit_date_of_birth(page, age)
 

--- a/lung_cancer_screening/core/tests/acceptance/test_questionnaire_validation_errors.py
+++ b/lung_cancer_screening/core/tests/acceptance/test_questionnaire_validation_errors.py
@@ -3,8 +3,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from playwright.sync_api import sync_playwright, expect
 
 from .helpers.user_interaction_helpers import (
-    fill_in_and_submit_participant_id,
-    fill_in_and_submit_smoking_elligibility
+    fill_in_and_submit_participant_id
 )
 
 class TestQuestionnaireValidationErrors(StaticLiveServerTestCase):
@@ -22,26 +21,19 @@ class TestQuestionnaireValidationErrors(StaticLiveServerTestCase):
         cls.browser.close()
         cls.playwright.stop()
 
-    def test_full_questionaire_user_journey_with_validation_errors(self):
+    def test_date_of_birth_validation_errors(self):
         participant_id = '123'
 
         page = self.browser.new_page()
         page.goto(f"{self.live_server_url}/start")
-
         fill_in_and_submit_participant_id(page, participant_id)
-        fill_in_and_submit_smoking_elligibility(page, 'Yes, I currently smoke')
+        page.goto(f"{self.live_server_url}/date-of-birth")
 
         expect(page.locator("legend")).to_have_text(
             "What is your date of birth?")
 
-        page.get_by_label("Day").fill("100")
-        page.get_by_label("Month").fill("100")
-        page.get_by_label("Year").fill("some string")
-
         page.click("text=Continue")
 
-        expect(page).to_have_url(f"{self.live_server_url}/date-of-birth")
-
         expect(page.locator(".nhsuk-error-message")).to_contain_text(
-            "Day should be between 1 and 31"
+            "Enter your date of birth."
         )

--- a/lung_cancer_screening/questions/forms/date_of_birth_form.py
+++ b/lung_cancer_screening/questions/forms/date_of_birth_form.py
@@ -13,8 +13,8 @@ class DateOfBirthForm(forms.ModelForm):
         self.fields["date_of_birth"] = SplitDateField(
             max_value=date.today(),
             required=False,
-            hint="For example, 15 3 2025",
-            label="What is your date of birth?"
+            label="What is your date of birth?",
+            hint="For example, 15 3 1965"
         )
 
     class Meta:

--- a/lung_cancer_screening/questions/forms/date_of_birth_form.py
+++ b/lung_cancer_screening/questions/forms/date_of_birth_form.py
@@ -12,9 +12,15 @@ class DateOfBirthForm(forms.ModelForm):
 
         self.fields["date_of_birth"] = SplitDateField(
             max_value=date.today(),
-            required=False,
+            required=True,
+            require_all_fields=False,
             label="What is your date of birth?",
-            hint="For example, 15 3 1965"
+            hint="For example, 15 3 1965",
+            error_messages={
+                'required': 'Enter your date of birth.',
+                'incomplete': 'Enter your full date of birth.',
+                'invalid': 'Date of birth must be a real date.'
+            }
         )
 
     class Meta:

--- a/lung_cancer_screening/questions/jinja2/date_of_birth.jinja
+++ b/lung_cancer_screening/questions/jinja2/date_of_birth.jinja
@@ -2,12 +2,22 @@
 
 {% from 'nhsuk/components/date-input/macro.jinja' import dateInput %}
 {% from 'nhsuk/components/button/macro.jinja' import button %}
+{% from 'nhsuk/components/back-link/macro.jinja' import backLink %}
 
 {% if error %}
   {% set error_message = { "text": error } %}
 {% endif %}
 
-{% block content %}
+{% block beforeContent %}
+  {{
+    backLink({
+      "href": url("questions:have_you_ever_smoked"),
+      "text": "Back"
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block page_content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
       <form action="{{ request.path }}" method="POST">

--- a/lung_cancer_screening/questions/tests/unit/forms/test_date_of_birth_form.py
+++ b/lung_cancer_screening/questions/tests/unit/forms/test_date_of_birth_form.py
@@ -8,7 +8,7 @@ class TestDateOfBirthForm(TestCase):
     def setUp(self):
         self.participant = Participant.objects.create(unique_id="1234567890")
 
-    def test_is_valid(self):
+    def test_is_valid_when_a_valid_date_is_provided(self):
         form = DateOfBirthForm(
             participant=self.participant,
             data={
@@ -19,17 +19,53 @@ class TestDateOfBirthForm(TestCase):
         )
         self.assertTrue(form.is_valid())
 
-    def test_is_invalid(self):
+    def test_is_invalid_when_no_date_is_provided(self):
         form = DateOfBirthForm(
             participant=self.participant,
             data={
-                "date_of_birth_0": 100,
-                "date_of_birth_1": 100,
-                "date_of_birth_2": 2025
+                "date_of_birth_0": "",
+                "date_of_birth_1": "",
+                "date_of_birth_2": ""
             }
         )
 
         self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["date_of_birth"],
+            ["Enter your date of birth."]
+        )
+
+    def test_is_invalid_when_a_partial_date_is_provided(self):
+        form = DateOfBirthForm(
+            participant=self.participant,
+            data={
+                "date_of_birth_0": "10",
+                "date_of_birth_1": "",
+                "date_of_birth_2": ""
+            }
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["date_of_birth"],
+            ["Enter your full date of birth."]
+        )
+
+    def test_is_invalid_when_an_invalid_date_is_provided(self):
+        form = DateOfBirthForm(
+            participant=self.participant,
+            data={
+                "date_of_birth_0": "31",
+                "date_of_birth_1": "02",
+                "date_of_birth_2": "2025"
+            }
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["date_of_birth"],
+            ["Date of birth must be a real date."]
+        )
 
     def test_returns_a_date_type(self):
         form = DateOfBirthForm(

--- a/scripts/config/pre-commit.yaml
+++ b/scripts/config/pre-commit.yaml
@@ -31,10 +31,10 @@ repos:
     args: ["check=staged-changes"]
     language: script
     pass_filenames: false
-# - repo: local
-#   hooks:
-#   - id: lint-terraform
-#     name: Lint Terraform
-#     entry: ./scripts/githooks/check-terraform-format.sh
-#     language: script
-#     pass_filenames: false
+- repo: local
+  hooks:
+  - id: lint-terraform
+    name: Lint Terraform
+    entry: ./scripts/githooks/check-terraform-format.sh
+    language: script
+    pass_filenames: false

--- a/scripts/terraform/terraform.mk
+++ b/scripts/terraform/terraform.mk
@@ -71,3 +71,6 @@ terraform-destroy: terraform-init # Destroy Terraform resources - make <env> ter
 
 terraform-validate: terraform-init-no-backend # Validate Terraform changes - make <env> terraform-validate
 	terraform -chdir=infrastructure/terraform validate
+
+terraform-fmt:
+	terraform -chdir=infrastructure/terraform fmt


### PR DESCRIPTION
# What is the change?

* Add back link to smoking page from date of birth page
* Added custom error messages to date of birth form to align with Figma designs
* Upgrade precommit

# Why are we making this change?

The date of birth page alreadys exists from a previous spike. This PR brings the date of birth page inline with the Figma designs