### PR TITLE
Ppha 765 former smoker navigation

### DIFF
--- a/features/age_when_started_smoking.feature
+++ b/features/age_when_started_smoking.feature
@@ -1,6 +1,5 @@
 @SmokingHistory
 @AgeWhenStartedSmoking
-@wip
 Feature: Age when started smoking
   Scenario: The page is accessible
     Given I am logged in

--- a/features/age_when_started_smoking.feature
+++ b/features/age_when_started_smoking.feature
@@ -1,5 +1,6 @@
 @SmokingHistory
 @AgeWhenStartedSmoking
+@wip
 Feature: Age when started smoking
   Scenario: The page is accessible
     Given I am logged in
@@ -52,7 +53,7 @@ Feature: Age when started smoking
     Then I am on "/age-when-started-smoking?change=True"
     And I see "18" filled in for "How old were you when you started smoking?"
     When I fill in "How old were you when you started smoking?" as "22" and submit
-    Then I am on "/periods-when-you-stopped-smoking?change=True"
+    Then I am on "/check-your-answers"
 
   Scenario: Checking responses and changing them as a former smoker
     Given I am logged in
@@ -67,4 +68,4 @@ Feature: Age when started smoking
     Then I am on "/age-when-started-smoking?change=True"
     And I see "18" filled in for "How old were you when you started smoking?"
     When I fill in "How old were you when you started smoking?" as "22" and submit
-    Then I am on "/when-you-quit-smoking?change=True"
+    Then I am on "/check-your-answers"

--- a/features/questionnaire.feature
+++ b/features/questionnaire.feature
@@ -76,13 +76,6 @@ Feature: Questionnaire
     When I check "Cigarettes"
     And I submit the form
 
-    Then I am on "/cigarettes-smoking-current"
-    When I check "Yes" and submit
-
-    Then I am on "/cigarettes-smoked-total-years"
-    When I fill in "Roughly how many years have you smoked cigarettes?" with "10"
-    And I submit the form
-
     Then I am on "/cigarettes-smoking-frequency"
     When I check "Daily" and submit
 
@@ -113,7 +106,7 @@ Feature: Questionnaire
     And I see "18" as a response to "Age you started smoking" under "Smoking history"
     And I see "Yes (10 years)" as a response to "Have you ever stopped smoking for periods of 1 year or longer?" under "Smoking history"
 
-    And I see "10" as a response to "Total number of years you smoked cigarettes" under "Smoking history"
+    And I see "37" as a response to "Total number of years you smoked cigarettes" under "Smoking history"
     And I see "15 cigarettes a day" as a response to "Current cigarette smoking" under "Smoking history"
 
     When I click "Submit"

--- a/features/smoked_amount.feature
+++ b/features/smoked_amount.feature
@@ -4,6 +4,7 @@ Feature: Smoked amount page
   Scenario: The page is accessible
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I currently smoke "Cigarettes"
     And I have answered questions showing I have smoked "Cigarettes" daily
     When I go to "/cigarettes-smoked-amount"
@@ -12,6 +13,7 @@ Feature: Smoked amount page
   Scenario: Form errors
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I currently smoke "Cigarettes"
     And I have answered questions showing I have smoked "Cigarettes" daily
     When I go to "/cigarettes-smoked-amount"
@@ -23,6 +25,7 @@ Feature: Smoked amount page
   Scenario: Navigating backwards and forwards
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I currently smoke "Cigarettes"
     And I have answered questions showing I have smoked "Cigarettes" daily
     When I go to "/cigarettes-smoked-amount"

--- a/features/smoked_total_years.feature
+++ b/features/smoked_total_years.feature
@@ -14,7 +14,7 @@ Feature: Smoked total years page
     Given I am logged in
     And I have answered questions showing I am eligible
     And I have answered questions showing I have smoked for "10" years
-    And I have answered questions showing I have smoked "Cigarettes"
+    And I have answered questions showing I have smoked "Cigarettes, Pipe"
     And I have answered questions showing I currently smoke "Cigarettes"
     When I go to "/cigarettes-smoked-total-years"
     And I click "Continue"

--- a/features/smoking_change.feature
+++ b/features/smoking_change.feature
@@ -3,6 +3,7 @@ Feature: Smoking change page
   Scenario: The page is accessible
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I currently smoke "Cigarettes"
     And I have answered questions showing I have smoked 10 "Cigarettes" "daily"
     When I go to "/cigarettes-smoking-change"
@@ -11,6 +12,7 @@ Feature: Smoking change page
   Scenario: Form errors
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I currently smoke "Cigarettes"
     And I have answered questions showing I have smoked 10 "Cigarettes" "daily"
     When I go to "/cigarettes-smoking-change"
@@ -25,6 +27,7 @@ Feature: Smoking change page
   Scenario: Navigating backwards and forwards
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I currently smoke "Cigarettes"
     And I have answered questions showing I have smoked 10 "Cigarettes" "daily"
     When I go to "/cigarettes-smoking-change"

--- a/features/smoking_current.feature
+++ b/features/smoking_current.feature
@@ -11,7 +11,7 @@ Feature: Smoking current page
   Scenario: Form errors
     Given I am logged in
     And I have answered questions showing I am eligible
-    And I have answered questions showing I have smoked "Cigarettes"
+    And I have answered questions showing I have smoked "Cigarettes, Pipe"
     When I go to "/cigarettes-smoking-current"
     And I click "Continue"
     Then I am on "/cigarettes-smoking-current"

--- a/features/smoking_current.feature
+++ b/features/smoking_current.feature
@@ -4,6 +4,7 @@ Feature: Smoking current page
   Scenario: The page is accessible
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I have smoked "Cigarettes"
     When I go to "/cigarettes-smoking-current"
     Then there are no accessibility violations
@@ -11,6 +12,7 @@ Feature: Smoking current page
   Scenario: Form errors
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I have smoked "Cigarettes, Pipe"
     When I go to "/cigarettes-smoking-current"
     And I click "Continue"

--- a/features/smoking_frequency.feature
+++ b/features/smoking_frequency.feature
@@ -4,6 +4,7 @@ Feature: Smoking frequency page
   Scenario: The page is accessible
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I have smoked "Cigarettes"
     And I have answered questions showing I currently smoke "Cigarettes"
     When I go to "/cigarettes-smoking-frequency"
@@ -12,6 +13,7 @@ Feature: Smoking frequency page
   Scenario: Form errors
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I have smoked "Cigarettes"
     And I have answered questions showing I currently smoke "Cigarettes"
     When I go to "/cigarettes-smoking-frequency"
@@ -33,6 +35,7 @@ Feature: Smoking frequency page
   Scenario: When I say that I have increased the amount I smoke I am shown the correct page
     Given I am logged in
     And I have answered questions showing I am eligible
+    And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I currently smoke "Cigarettes"
     And I have answered questions showing I have smoked 10 "Cigarettes" "daily"
     And I have answered questions showing I have "increased" my level of "Cigarettes" smoking from "10 cigarettes a day"

--- a/features/smoking_frequency.feature
+++ b/features/smoking_frequency.feature
@@ -25,9 +25,8 @@ Feature: Smoking frequency page
     And I have answered questions showing I am eligible
     And I have answered questions showing I have smoked for "10" years
     And I have answered questions showing I currently smoke "Cigarettes"
-    And I have answered questions showing I have smoked "Cigarettes"
     When I go to "/cigarettes-smoking-frequency"
-    Then I see a back link to "/cigarettes-smoked-total-years"
+    Then I see a back link to "/types-tobacco-smoking"
     When I check "Daily" and submit
     Then I am on "/cigarettes-smoked-amount"
 

--- a/features/smoking_history.feature
+++ b/features/smoking_history.feature
@@ -6,15 +6,6 @@ Feature: Smoking history pages
     And I have answered questions showing I have smoked for "30" years
     When I go to "/types-tobacco-smoking"
     And I check "Cigarettes"
-    And I check "Cigarettes"
-    And I submit the form
-
-    Then I am on "/cigarettes-smoking-current"
-    When I check "Yes"
-    And I submit the form
-
-    Then I am on "/cigarettes-smoked-total-years"
-    When I fill in "Roughly how many years have you smoked cigarettes?" with "15"
     And I submit the form
 
     Then I am on "/cigarettes-smoking-frequency"
@@ -55,7 +46,7 @@ Feature: Smoking history pages
     And I submit the form
 
     Then I am on "/check-your-answers"
-    Then I see "15 years" as a response to "Total number of years you smoked cigarettes" under "Cigarette smoking history"
+    Then I see "30 years" as a response to "Total number of years you smoked cigarettes" under "Cigarette smoking history"
     And I see "10 cigarettes a day" as a response to "Current cigarette smoking" under "Cigarette smoking history"
     And I see "200 cigarettes a week for 5 years" as a response to "When you smoked more than 10 cigarettes a day" under "Cigarette smoking history"
     And I see "1 cigarettes a month for 2 years" as a response to "When you smoked fewer than 10 cigarettes a day" under "Cigarette smoking history"

--- a/features/steps/navigation_steps.py
+++ b/features/steps/navigation_steps.py
@@ -1,8 +1,8 @@
-from behave import when, then
+from behave import when, then, step
 from playwright.sync_api import expect
 
 
-@when('I go to "{path}"')
+@step('I go to "{path}"')
 def given_i_go_to(context, path):
     context.page.goto(f"{context.live_server_url}{path}")
 

--- a/features/steps/preflight_steps.py
+++ b/features/steps/preflight_steps.py
@@ -96,6 +96,11 @@ def given_i_have_answered_questions_showing_i_am_aged_60_years_old(context, year
     context.page.goto(f"{context.live_server_url}/date-of-birth")
     when_i_fill_in_and_submit_my_date_of_birth_as_x_years_ago(context, years)
 
+@given("I have answered questions showing I quit smoking at \"{years}\" years old")
+def given_i_have_answered_questions_showing_i_quit_smoking_at_years_old(context, years):
+    context.page.goto(f"{context.live_server_url}/when-you-quit-smoking")
+    when_i_fill_in_label_with_value(context, "How old were you when you quit smoking?", years)
+    when_i_submit_the_form(context)
 
 @given('I have answered questions showing I stopped smoking for "{years}" years')
 def given_i_have_answered_questions_showing_i_stopped_smoking_for_years_years(context, years):

--- a/features/types_tobacco_smoking.feature
+++ b/features/types_tobacco_smoking.feature
@@ -18,7 +18,7 @@ Feature: Types tobacco smoking page
     And I see a form error "Select the type of tobacco you smoke or have smoked"
     And there are no accessibility violations
 
-  Scenario: Navigating backwards and forwards
+  Scenario: Current smokers navigating backwards and forwards
     Given I am logged in
     And I have answered questions showing I am eligible
     And I have answered questions showing I have smoked for "10" years
@@ -33,6 +33,29 @@ Feature: Types tobacco smoking page
     When I check "Pipe"
     And I click "Continue"
     Then I am on "/cigarettes-smoking-current"
+    And I see a back link to "/types-tobacco-smoking"
+
+  Scenario: Former smokers navigating backwards and forwards
+    Given I am logged in
+    And I have answered questions showing I am eligible
+    And I have answered questions showing I am aged "70" years old
+    And I have answered questions showing I am a former smoker
+    And I have answered questions showing I have smoked for "50" years
+    And I have answered questions showing I quit smoking at "50" years old
+    And I go to "/check-your-answers"
+    And I take a screenshot
+    When I go to "/types-tobacco-smoking"
+    Then I see a back link to "/periods-when-you-stopped-smoking"
+    When I check "Cigarettes"
+    And I take a screenshot
+    And I submit the form
+    Then I am on "/cigarettes-smoking-frequency"
+    When I click "Back"
+    Then I am on "/types-tobacco-smoking"
+    And I see "Cigarettes" selected
+    When I check "Pipe"
+    And I click "Continue"
+    Then I am on "/cigarettes-smoked-total-years"
     And I see a back link to "/types-tobacco-smoking"
 
   Scenario: Checking responses and changing them

--- a/features/types_tobacco_smoking.feature
+++ b/features/types_tobacco_smoking.feature
@@ -26,7 +26,7 @@ Feature: Types tobacco smoking page
     Then I see a back link to "/periods-when-you-stopped-smoking"
     When I check "Cigarettes"
     And I submit the form
-    Then I am on "/cigarettes-smoking-current"
+    Then I am on "/cigarettes-smoking-frequency"
 
   Scenario: Checking responses and changing them
     Given I am logged in

--- a/features/types_tobacco_smoking.feature
+++ b/features/types_tobacco_smoking.feature
@@ -27,6 +27,13 @@ Feature: Types tobacco smoking page
     When I check "Cigarettes"
     And I submit the form
     Then I am on "/cigarettes-smoking-frequency"
+    When I click "Back"
+    Then I am on "/types-tobacco-smoking"
+    And I see "Cigarettes" selected
+    When I check "Pipe"
+    And I click "Continue"
+    Then I am on "/cigarettes-smoking-current"
+    And I see a back link to "/types-tobacco-smoking"
 
   Scenario: Checking responses and changing them
     Given I am logged in

--- a/lung_cancer_screening/questions/forms/types_tobacco_smoking_form.py
+++ b/lung_cancer_screening/questions/forms/types_tobacco_smoking_form.py
@@ -90,7 +90,7 @@ class TypesTobaccoSmokingForm(forms.Form):
 
     def _create_default_responses_for_single_selection(self):
         response_set = self.response_set
-        instances = response_set.tobacco_smoking_history
+        instances = response_set.tobacco_smoking_history.normal()
         if instances.count() == 1:
             instance = instances.first()
 

--- a/lung_cancer_screening/questions/forms/types_tobacco_smoking_form.py
+++ b/lung_cancer_screening/questions/forms/types_tobacco_smoking_form.py
@@ -1,5 +1,8 @@
 from django import forms
 
+from lung_cancer_screening.questions.models.smoked_total_years_response import SmokedTotalYearsResponse
+from lung_cancer_screening.questions.models.smoking_current_response import SmokingCurrentResponse
+
 from ...nhsuk_forms.choice_field import MultipleChoiceField
 from ..models.tobacco_smoking_history import (
     TobaccoSmokingHistory,
@@ -81,4 +84,26 @@ class TypesTobaccoSmokingForm(forms.Form):
 
         TobaccoSmokingHistory.objects.bulk_create(instances)
 
+        self._create_default_responses_for_single_selection()
+
         return instances
+
+    def _create_default_responses_for_single_selection(self):
+        response_set = self.response_set
+        instances = response_set.tobacco_smoking_history
+        if instances.count() == 1:
+            instance = instances.first()
+
+            SmokingCurrentResponse.objects.update_or_create(
+                tobacco_smoking_history=instance,
+                defaults={
+                    "value": response_set.current_smoker()
+                },
+            )
+
+            SmokedTotalYearsResponse.objects.update_or_create(
+                tobacco_smoking_history=instance,
+                defaults={
+                    "value": response_set.age_when_started_smoking_response.years_smoked_including_stopped()
+                }
+            )

--- a/lung_cancer_screening/questions/tests/unit/forms/test_types_tobacco_smoking_form.py
+++ b/lung_cancer_screening/questions/tests/unit/forms/test_types_tobacco_smoking_form.py
@@ -1,7 +1,10 @@
 from django.test import TestCase, tag
 
+from ...factories.age_when_started_smoking_response_factory import AgeWhenStartedSmokingResponseFactory
+
 from ...factories.response_set_factory import ResponseSetFactory
 from ...factories.tobacco_smoking_history_factory import TobaccoSmokingHistoryFactory
+from ...factories.have_you_ever_smoked_response_factory import HaveYouEverSmokedResponseFactory
 from ....models.tobacco_smoking_history import (
     TobaccoSmokingHistoryTypes,
 )
@@ -102,6 +105,9 @@ class TestTypesTobaccoSmokingForm(TestCase):
     def test_does_not_create_a_new_tobacco_smoking_type_if_it_already_exists(self):
         TobaccoSmokingHistoryFactory(response_set=self.response_set, cigarettes=True)
 
+        HaveYouEverSmokedResponseFactory(response_set=self.response_set, current_smoker=True)
+        AgeWhenStartedSmokingResponseFactory(response_set=self.response_set, value=20)
+
         form = TypesTobaccoSmokingForm(
             response_set=self.response_set,
             data={
@@ -115,6 +121,10 @@ class TestTypesTobaccoSmokingForm(TestCase):
 
     def test_deletes_a_tobacco_smoking_type_if_it_is_no_longer_selected(self):
         TobaccoSmokingHistoryFactory(response_set=self.response_set, cigarettes=True)
+
+        HaveYouEverSmokedResponseFactory(response_set=self.response_set, current_smoker=True)
+
+        AgeWhenStartedSmokingResponseFactory(response_set=self.response_set, value=20)
 
         form = TypesTobaccoSmokingForm(
             response_set=self.response_set,

--- a/lung_cancer_screening/questions/tests/unit/views/test_age_when_started_smoking.py
+++ b/lung_cancer_screening/questions/tests/unit/views/test_age_when_started_smoking.py
@@ -159,7 +159,7 @@ class TestPostAgeWhenStartedSmoking(TestCase):
 
         self.assertRedirects(
             response,
-            reverse("questions:periods_when_you_stopped_smoking", query={"change": "True"})
+            reverse("questions:responses")
         )
 
 
@@ -195,7 +195,7 @@ class TestPostAgeWhenStartedSmoking(TestCase):
 
         self.assertRedirects(
             response,
-            reverse("questions:when_you_quit_smoking", query={"change": "True"})
+            reverse("questions:responses")
         )
 
 

--- a/lung_cancer_screening/questions/tests/unit/views/test_smoking_frequency.py
+++ b/lung_cancer_screening/questions/tests/unit/views/test_smoking_frequency.py
@@ -86,7 +86,14 @@ class TestGetSmokingFrequency(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    def test_back_link_normal_level(self):
+    def test_back_link_normal_level_multiple_types(self):
+        self.tobacco_smoking_history = TobaccoSmokingHistoryFactory.create(
+            response_set=self.response_set,
+            cigarettes=True,
+            pipe=True,
+            complete=True
+        )
+
         response = self.client.get(reverse("questions:smoking_frequency", kwargs = {
                 "tobacco_type": TobaccoSmokingHistoryTypes.CIGARETTES.value.lower()
             }))
@@ -94,6 +101,16 @@ class TestGetSmokingFrequency(TestCase):
         self.assertEqual(
             response.context_data["back_link_url"],
             "/cigarettes-smoked-total-years",
+        )
+
+    def test_back_link_normal_level_single_type(self):
+        response = self.client.get(reverse("questions:smoking_frequency", kwargs = {
+                "tobacco_type": TobaccoSmokingHistoryTypes.CIGARETTES.value.lower()
+            }))
+
+        self.assertEqual(
+            response.context_data["back_link_url"],
+            "/types-tobacco-smoking",
         )
 
     def test_back_link_increased_level(self):

--- a/lung_cancer_screening/questions/tests/unit/views/test_types_tobacco_smoking.py
+++ b/lung_cancer_screening/questions/tests/unit/views/test_types_tobacco_smoking.py
@@ -55,7 +55,12 @@ class TestGetTypesTobaccoSmoking(TestCase):
 
 
     def test_get_responds_successfully(self):
-        ResponseSetFactory.create(user=self.user, eligible=True)
+        response_set = ResponseSetFactory.create(user=self.user, eligible=True)
+
+        AgeWhenStartedSmokingResponseFactory.create(
+            response_set=response_set,
+            value=20
+        )
 
         response = self.client.get(
             reverse("questions:types_tobacco_smoking")
@@ -64,7 +69,12 @@ class TestGetTypesTobaccoSmoking(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_get_back_link_url_returns_responses_url_if_changing_responses(self):
-        ResponseSetFactory.create(user=self.user, eligible=True)
+        response_set = ResponseSetFactory.create(user=self.user, eligible=True)
+
+        AgeWhenStartedSmokingResponseFactory.create(
+            response_set=response_set,
+            value=20
+        )
 
         response = self.client.get(
             reverse("questions:types_tobacco_smoking") + "?change=True"
@@ -76,7 +86,12 @@ class TestGetTypesTobaccoSmoking(TestCase):
         )
 
     def test_get_back_link_url_returns_periods_when_you_stopped_smoking_url_if_not_changing_responses(self):
-        ResponseSetFactory.create(user=self.user, eligible=True)
+        response_set = ResponseSetFactory.create(user=self.user, eligible=True)
+
+        AgeWhenStartedSmokingResponseFactory.create(
+            response_set=response_set,
+            value=20
+        )
 
         response = self.client.get(
             reverse("questions:types_tobacco_smoking")
@@ -147,9 +162,15 @@ class TestPostTypesTobaccoSmoking(TestCase):
         self.assertEqual(response_set.tobacco_smoking_history.count(), 1)
         self.assertEqual(response_set.tobacco_smoking_history.first().type, TobaccoSmokingHistoryTypes.CIGARETTES.value)
 
-
+    @tag("wip")
     def test_post_redirects_to_the_current_of_first_type_of_tobacco_smoking_history_if_multiple_types_given(self):
-        ResponseSetFactory.create(user=self.user, eligible=True)
+        response_set = ResponseSetFactory.create(user=self.user, eligible=True)
+
+        AgeWhenStartedSmokingResponseFactory.create(
+            response_set=response_set,
+            value=20
+        )
+
         response = self.client.post(
             reverse("questions:types_tobacco_smoking"),
             {"value": [TobaccoSmokingHistoryTypes.CIGARETTES.value, TobaccoSmokingHistoryTypes.PIPE.value]}

--- a/lung_cancer_screening/questions/tests/unit/views/test_types_tobacco_smoking.py
+++ b/lung_cancer_screening/questions/tests/unit/views/test_types_tobacco_smoking.py
@@ -162,7 +162,6 @@ class TestPostTypesTobaccoSmoking(TestCase):
         self.assertEqual(response_set.tobacco_smoking_history.count(), 1)
         self.assertEqual(response_set.tobacco_smoking_history.first().type, TobaccoSmokingHistoryTypes.CIGARETTES.value)
 
-    @tag("wip")
     def test_post_redirects_to_the_current_of_first_type_of_tobacco_smoking_history_if_multiple_types_given(self):
         response_set = ResponseSetFactory.create(user=self.user, eligible=True)
 

--- a/lung_cancer_screening/questions/tests/unit/views/test_types_tobacco_smoking.py
+++ b/lung_cancer_screening/questions/tests/unit/views/test_types_tobacco_smoking.py
@@ -2,6 +2,8 @@ from django.test import TestCase, tag
 from django.urls import reverse
 from django.utils.text import slugify
 
+from lung_cancer_screening.questions.tests.factories.smoked_total_years_response_factory import SmokedTotalYearsResponseFactory
+
 from .helpers.authentication import login_user
 from ...factories.response_set_factory import ResponseSetFactory
 from ....models.tobacco_smoking_history import TobaccoSmokingHistoryTypes
@@ -142,13 +144,33 @@ class TestPostTypesTobaccoSmoking(TestCase):
         self.assertEqual(response_set.tobacco_smoking_history.first().type, TobaccoSmokingHistoryTypes.CIGARETTES.value)
 
 
-    def test_post_redirects_to_the_first_type_of_tobacco_smoking_history_question(self):
+    def test_post_redirects_to_the_current_of_first_type_of_tobacco_smoking_history_if_multiple_types_given(self):
         ResponseSetFactory.create(user=self.user, eligible=True)
         response = self.client.post(
             reverse("questions:types_tobacco_smoking"),
-            self.valid_params
+            {"value": [TobaccoSmokingHistoryTypes.CIGARETTES.value, TobaccoSmokingHistoryTypes.PIPE.value]}
         )
 
         self.assertRedirects(response, reverse("questions:smoking_current", kwargs={
             "tobacco_type": slugify(TobaccoSmokingHistoryTypes.CIGARETTES.value)
         }), fetch_redirect_response=False)
+
+    @tag("wip")
+    def test_post_redirects_to_frequency_if_one_type_of_tobacco_smoking_history_given(self):
+        response_set = ResponseSetFactory.create(user=self.user, eligible=True)
+
+        response = self.client.post(
+            reverse("questions:types_tobacco_smoking"),
+             {"value": [TobaccoSmokingHistoryTypes.PIPE.value]}
+        )
+
+        self.assertRedirects(response, reverse("questions:smoking_frequency", kwargs={
+            "tobacco_type": slugify(TobaccoSmokingHistoryTypes.PIPE.value)
+        }), fetch_redirect_response=False)
+
+        response_set.tobacco_smoking_history.first().refresh_from_db()
+        print(response_set.tobacco_smoking_history.first().is_current())
+        self.assertTrue(response_set.tobacco_smoking_history.first().is_pipe())
+        self.assertTrue(response_set.tobacco_smoking_history.first().is_current())
+        print(response_set.tobacco_smoking_history.first().duration_years())
+        #self.assertTrue(response_set.tobacco_smoking_history.first().duration_years() == 5)

--- a/lung_cancer_screening/questions/tests/unit/views/test_types_tobacco_smoking.py
+++ b/lung_cancer_screening/questions/tests/unit/views/test_types_tobacco_smoking.py
@@ -169,7 +169,7 @@ class TestPostTypesTobaccoSmoking(TestCase):
 
         response = self.client.post(
             reverse("questions:types_tobacco_smoking"),
-             {"value": [TobaccoSmokingHistoryTypes.PIPE.value]}
+            {"value": [TobaccoSmokingHistoryTypes.PIPE.value]}
         )
 
         self.assertRedirects(response, reverse("questions:smoking_frequency", kwargs={
@@ -210,7 +210,7 @@ class TestPostTypesTobaccoSmoking(TestCase):
 
         response = self.client.post(
             reverse("questions:types_tobacco_smoking"),
-             {"value": [TobaccoSmokingHistoryTypes.PIPE.value]}
+            {"value": [TobaccoSmokingHistoryTypes.PIPE.value]}
         )
 
         self.assertRedirects(response, reverse("questions:smoking_frequency", kwargs={

--- a/lung_cancer_screening/questions/tests/unit/views/test_types_tobacco_smoking.py
+++ b/lung_cancer_screening/questions/tests/unit/views/test_types_tobacco_smoking.py
@@ -2,7 +2,9 @@ from django.test import TestCase, tag
 from django.urls import reverse
 from django.utils.text import slugify
 
-from lung_cancer_screening.questions.tests.factories.smoked_total_years_response_factory import SmokedTotalYearsResponseFactory
+from ...factories.age_when_started_smoking_response_factory import AgeWhenStartedSmokingResponseFactory
+from ...factories.have_you_ever_smoked_response_factory import HaveYouEverSmokedResponseFactory
+from ...factories.when_you_quit_smoking_response_factory import WhenYouQuitSmokingResponseFactory
 
 from .helpers.authentication import login_user
 from ...factories.response_set_factory import ResponseSetFactory
@@ -134,6 +136,8 @@ class TestPostTypesTobaccoSmoking(TestCase):
     def test_creates_a_tobacco_smoking_type_parent_model_for_each_type_given(self):
         response_set = ResponseSetFactory.create(user=self.user, eligible=True)
 
+        AgeWhenStartedSmokingResponseFactory(response_set=response_set, value=20)
+
         self.client.post(
             reverse("questions:types_tobacco_smoking"),
             self.valid_params
@@ -155,9 +159,13 @@ class TestPostTypesTobaccoSmoking(TestCase):
             "tobacco_type": slugify(TobaccoSmokingHistoryTypes.CIGARETTES.value)
         }), fetch_redirect_response=False)
 
-    @tag("wip")
     def test_post_redirects_to_frequency_if_one_type_of_tobacco_smoking_history_given(self):
         response_set = ResponseSetFactory.create(user=self.user, eligible=True)
+
+        AgeWhenStartedSmokingResponseFactory.create(
+            response_set=response_set,
+            value=20
+        )
 
         response = self.client.post(
             reverse("questions:types_tobacco_smoking"),
@@ -169,8 +177,49 @@ class TestPostTypesTobaccoSmoking(TestCase):
         }), fetch_redirect_response=False)
 
         response_set.tobacco_smoking_history.first().refresh_from_db()
-        print(response_set.tobacco_smoking_history.first().is_current())
+
         self.assertTrue(response_set.tobacco_smoking_history.first().is_pipe())
         self.assertTrue(response_set.tobacco_smoking_history.first().is_current())
-        print(response_set.tobacco_smoking_history.first().duration_years())
-        #self.assertTrue(response_set.tobacco_smoking_history.first().duration_years() == 5)
+
+        age = response_set.date_of_birth_response.age_in_years()
+        age_started = response_set.age_when_started_smoking_response.value
+
+        self.assertEqual(response_set.tobacco_smoking_history.first().duration_years(), age-age_started)
+
+
+    def test_post_redirects_to_frequency_if_one_type_of_tobacco_smoking_history_given_for_former_smoker(self):
+        response_set = ResponseSetFactory.create(user=self.user, eligible=True)
+
+        AgeWhenStartedSmokingResponseFactory.create(
+            response_set=response_set,
+            value=20
+        )
+
+        response_set.have_you_ever_smoked_response.delete()
+
+        HaveYouEverSmokedResponseFactory.create(
+            response_set=response_set,
+            former_smoker=True,
+        )
+
+        age_when_quit = 30
+        WhenYouQuitSmokingResponseFactory.create(
+            response_set=response_set,
+            value=age_when_quit
+        )
+
+        response = self.client.post(
+            reverse("questions:types_tobacco_smoking"),
+             {"value": [TobaccoSmokingHistoryTypes.PIPE.value]}
+        )
+
+        self.assertRedirects(response, reverse("questions:smoking_frequency", kwargs={
+            "tobacco_type": slugify(TobaccoSmokingHistoryTypes.PIPE.value)
+        }), fetch_redirect_response=False)
+
+        response_set.tobacco_smoking_history.first().refresh_from_db()
+
+        self.assertTrue(response_set.tobacco_smoking_history.first().is_pipe())
+        self.assertFalse(response_set.tobacco_smoking_history.first().is_current())
+
+        self.assertEqual(response_set.tobacco_smoking_history.first().duration_years(), 10)

--- a/lung_cancer_screening/questions/views/age_when_started_smoking.py
+++ b/lung_cancer_screening/questions/views/age_when_started_smoking.py
@@ -17,6 +17,8 @@ class AgeWhenStartedSmokingView(LoginRequiredMixin, EnsureResponseSet, EnsureEli
 
 
     def get_success_url(self):
+        if self.is_changing_responses():
+            return reverse("questions:responses")
         if self.request.response_set.current_smoker():
             url_lookup = "questions:periods_when_you_stopped_smoking"
         else:

--- a/lung_cancer_screening/questions/views/smoked_total_years.py
+++ b/lung_cancer_screening/questions/views/smoked_total_years.py
@@ -88,6 +88,8 @@ class SmokedTotalYearsView(
 
     def get_back_link_url(self):
         if self.tobacco_smoking_history_item().is_normal():
+            if self.request.response_set.former_smoker():
+                return reverse("questions:types_tobacco_smoking")
             return reverse(
                 "questions:smoking_current",
                 kwargs={"tobacco_type": self.kwargs["tobacco_type"]},

--- a/lung_cancer_screening/questions/views/smoking_frequency.py
+++ b/lung_cancer_screening/questions/views/smoking_frequency.py
@@ -46,7 +46,7 @@ class SmokingFrequencyView(
 
     def get_back_link_url(self):
         if not self.kwargs.get("level") :
-            if self.request.response_set.tobacco_smoking_history.count() == 1:
+            if self.request.response_set.tobacco_smoking_history.normal().count() == 1:
                 return reverse(
                     "questions:types_tobacco_smoking",
                 )

--- a/lung_cancer_screening/questions/views/smoking_frequency.py
+++ b/lung_cancer_screening/questions/views/smoking_frequency.py
@@ -46,11 +46,16 @@ class SmokingFrequencyView(
 
     def get_back_link_url(self):
         if not self.kwargs.get("level") :
-            return reverse(
-                "questions:smoked_total_years",
-                kwargs=self.kwargs,
-                query=self.get_change_query_params(),
-            )
+            if self.request.response_set.tobacco_smoking_history.count() == 1:
+                return reverse(
+                    "questions:types_tobacco_smoking",
+                )
+            else:
+                return reverse(
+                    "questions:smoked_total_years",
+                    kwargs=self.kwargs,
+                    query=self.get_change_query_params(),
+                )
 
         elif self.kwargs.get("level") == TobaccoSmokingHistory.Levels.INCREASED:
             return reverse(

--- a/lung_cancer_screening/questions/views/types_tobacco_smoking.py
+++ b/lung_cancer_screening/questions/views/types_tobacco_smoking.py
@@ -4,7 +4,9 @@ from django.views.generic.edit import FormView
 
 from .mixins.ensure_response_set import EnsureResponseSet
 from .mixins.ensure_eligible import EnsureEligibleMixin
+
 from ..forms.types_tobacco_smoking_form import TypesTobaccoSmokingForm
+from ..models.smoking_current_response import SmokingCurrentResponse
 
 
 class TypesTobaccoSmokingView(
@@ -30,10 +32,33 @@ class TypesTobaccoSmokingView(
         return super(TypesTobaccoSmokingView, self).form_valid(form)
 
     def get_success_url(self):
+        tobacco_smoking_history = self.request.response_set.tobacco_smoking_history.in_form_order()
+
         next_tobacco_smoking_history = (
-            self.request.response_set.tobacco_smoking_history
-            .in_form_order().first()
+            tobacco_smoking_history.in_form_order().first()
         )
+
+        if (tobacco_smoking_history.count() == 1):
+            print(f"is current smoker: {self.request.response_set.have_you_ever_smoked_response.is_current_smoker()}")
+
+            print(f"smoking current: {hasattr(next_tobacco_smoking_history, 'smoking_current_response')}")
+
+            print(f"next smoking history type: {next_tobacco_smoking_history.type}")
+
+            SmokingCurrentResponse.objects.update_or_create(
+                tobacco_smoking_history=next_tobacco_smoking_history,
+                value=self.request.response_set.have_you_ever_smoked_response.is_current_smoker()
+            )
+
+            print(f"smoking current: {next_tobacco_smoking_history.smoking_current_response}")
+
+            #age_started = self.request.response_set.age_when_started_smoking
+            #age_stopped = self.request.response_set.age_stopped_smoking_responses.first().value
+            #next_tobacco_smoking_history.smoked_total_years_response.value = 5
+            next_tobacco_smoking_history.save()
+            return reverse("questions:smoking_frequency", kwargs={
+                "tobacco_type": next_tobacco_smoking_history.url_type()
+            })
         return reverse(
             "questions:smoking_current",
             kwargs={

--- a/lung_cancer_screening/questions/views/types_tobacco_smoking.py
+++ b/lung_cancer_screening/questions/views/types_tobacco_smoking.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from django.shortcuts import redirect
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic.edit import FormView
 
@@ -7,8 +8,21 @@ from .mixins.ensure_eligible import EnsureEligibleMixin
 
 from ..forms.types_tobacco_smoking_form import TypesTobaccoSmokingForm
 
+class EnsureReadyForTobaccoTypesMixin:
+    def dispatch(self, request, *args, **kwargs):
+        if (
+            not hasattr(request.response_set, "age_when_started_smoking_response")
+        ):
+            return redirect(reverse("questions:age_when_started_smoking"))
+        if (
+            not hasattr(request.response_set, "when_you_quit_smoking_response")
+            and request.response_set.former_smoker()
+        ):
+            return redirect(reverse("questions:when_you_quit_smoking"))
+
+        return super().dispatch(request, *args, **kwargs)
 class TypesTobaccoSmokingView(
-    LoginRequiredMixin, EnsureResponseSet, EnsureEligibleMixin, FormView
+    LoginRequiredMixin, EnsureResponseSet, EnsureEligibleMixin, EnsureReadyForTobaccoTypesMixin, FormView
 ):
     template_name = "types_tobacco_smoking.jinja"
     form_class = TypesTobaccoSmokingForm
@@ -40,6 +54,14 @@ class TypesTobaccoSmokingView(
             return reverse("questions:smoking_frequency", kwargs={
                 "tobacco_type": next_tobacco_smoking_history.url_type()
             })
+
+        if self.request.response_set.former_smoker():
+            return reverse(
+                "questions:smoked_total_years",
+                kwargs={
+                    "tobacco_type": next_tobacco_smoking_history.url_type()
+                }
+            )
 
         return reverse(
             "questions:smoking_current",

--- a/lung_cancer_screening/questions/views/types_tobacco_smoking.py
+++ b/lung_cancer_screening/questions/views/types_tobacco_smoking.py
@@ -36,7 +36,7 @@ class TypesTobaccoSmokingView(
             tobacco_smoking_history.in_form_order().first()
         )
 
-        if (tobacco_smoking_history.count() == 1):
+        if (tobacco_smoking_history.normal().count() == 1):
             return reverse("questions:smoking_frequency", kwargs={
                 "tobacco_type": next_tobacco_smoking_history.url_type()
             })

--- a/lung_cancer_screening/questions/views/types_tobacco_smoking.py
+++ b/lung_cancer_screening/questions/views/types_tobacco_smoking.py
@@ -6,8 +6,6 @@ from .mixins.ensure_response_set import EnsureResponseSet
 from .mixins.ensure_eligible import EnsureEligibleMixin
 
 from ..forms.types_tobacco_smoking_form import TypesTobaccoSmokingForm
-from ..models.smoking_current_response import SmokingCurrentResponse
-
 
 class TypesTobaccoSmokingView(
     LoginRequiredMixin, EnsureResponseSet, EnsureEligibleMixin, FormView
@@ -39,26 +37,10 @@ class TypesTobaccoSmokingView(
         )
 
         if (tobacco_smoking_history.count() == 1):
-            print(f"is current smoker: {self.request.response_set.have_you_ever_smoked_response.is_current_smoker()}")
-
-            print(f"smoking current: {hasattr(next_tobacco_smoking_history, 'smoking_current_response')}")
-
-            print(f"next smoking history type: {next_tobacco_smoking_history.type}")
-
-            SmokingCurrentResponse.objects.update_or_create(
-                tobacco_smoking_history=next_tobacco_smoking_history,
-                value=self.request.response_set.have_you_ever_smoked_response.is_current_smoker()
-            )
-
-            print(f"smoking current: {next_tobacco_smoking_history.smoking_current_response}")
-
-            #age_started = self.request.response_set.age_when_started_smoking
-            #age_stopped = self.request.response_set.age_stopped_smoking_responses.first().value
-            #next_tobacco_smoking_history.smoked_total_years_response.value = 5
-            next_tobacco_smoking_history.save()
             return reverse("questions:smoking_frequency", kwargs={
                 "tobacco_type": next_tobacco_smoking_history.url_type()
             })
+
         return reverse(
             "questions:smoking_current",
             kwargs={


### PR DESCRIPTION
# What is the change?

Adding the skipping of current and total years smoked for current and former smokers when only selecting one type of tobacco smoked.

# Why are we making this change?

Prevents the repetition of questions when only one type of tobacco is being smoked by the user.