### PR TITLE
Ppha 810 create slack integration enable via schedule jobs

### DIFF
--- a/infrastructure/modules/container-apps/alerts.tf
+++ b/infrastructure/modules/container-apps/alerts.tf
@@ -1,35 +1,35 @@
-resource "azurerm_monitor_scheduled_query_rules_alert_v2" "five_hundred_error_alert" {
-  count = var.enable_alerting ? 1 : 0
+# resource "azurerm_monitor_scheduled_query_rules_alert_v2" "five_hundred_error_alert" {
+#   count = var.enable_alerting ? 1 : 0
 
-  auto_mitigation_enabled          = false
-  description                      = "An alert triggered by 500 errors logged in code"
-  enabled                          = var.enable_alerting
-  evaluation_frequency             = "PT5M"
-  location                         = var.region
-  name                             = "${var.app_short_name}-500-error-alert"
-  resource_group_name              = azurerm_resource_group.main.name
-  scopes                           = [var.action_group_id]
-  severity                         = 2
-  skip_query_validation            = false
-  window_duration                  = "PT5M"
-  workspace_alerts_storage_enabled = false
+#   auto_mitigation_enabled          = false
+#   description                      = "An alert triggered by 500 errors logged in code"
+#   enabled                          = var.enable_alerting
+#   evaluation_frequency             = "PT5M"
+#   location                         = var.region
+#   name                             = "${var.app_short_name}-500-error-alert"
+#   resource_group_name              = azurerm_resource_group.main.name
+#   scopes                           = [var.action_group_id]
+#   severity                         = 2
+#   skip_query_validation            = false
+#   window_duration                  = "PT5M"
+#   workspace_alerts_storage_enabled = false
 
-  action {
-    action_groups = [var.action_group_id]
-  }
+#   action {
+#     action_groups = [var.action_group_id]
+#   }
 
-  criteria {
-    operator                = "GreaterThan"
-    query                   = <<-QUERY
-      ContainerAppConsoleLogs_CL
-      | where Log contains "[ERROR]"
-      QUERY
-    threshold               = 0
-    time_aggregation_method = "Count"
+#   criteria {
+#     operator                = "GreaterThan"
+#     query                   = <<-QUERY
+#       ContainerAppConsoleLogs_CL
+#       | where Log contains "[ERROR]"
+#       QUERY
+#     threshold               = 0
+#     time_aggregation_method = "Count"
 
-    failing_periods {
-      minimum_failing_periods_to_trigger_alert = 1
-      number_of_evaluation_periods             = 1
-    }
-  }
-}
+#     failing_periods {
+#       minimum_failing_periods_to_trigger_alert = 1
+#       number_of_evaluation_periods             = 1
+#     }
+#   }
+# }

--- a/infrastructure/modules/container-apps/jobs.tf
+++ b/infrastructure/modules/container-apps/jobs.tf
@@ -40,6 +40,9 @@ module "db_setup" {
 }
 
 module "scheduled_jobs" {
+  # TODO: This should be on a scheduled job bases and NOT for the entire module
+  count = var.enable_alerting ? 1 : 0
+
   source = "../dtos-devops-templates/infrastructure/modules/container-app-job"
 
   for_each = local.scheduled_jobs


### PR DESCRIPTION
# What is the change?

To avoid spamming the slack channel, we have decided to disable the scheduled jobs for the lower environments and to only have it enabled on prod. 

Also removed the 500 error alert as it does not correctly work. This will be fixed next week

<!-- Describe the intended changes. -->

# Why are we making this change?

<!-- Why is this change required? What problem does it solve? -->
